### PR TITLE
Add HTTP server functionality for dynamic metadata updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ mvnw.cmd
 #additional resources
 flags
 filegen.jar
+
+#vscode
+.vscode

--- a/index.html
+++ b/index.html
@@ -1,0 +1,38 @@
+
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <script src="src/fetchControllerData.js"></script>
+</head>
+
+<body>
+    <span id="round_label"></span>
+    <span id="round_score_p1"></span>
+    <span id="round_score_p2"></span>
+    <span id="round_isGF"></span>
+    <span id="round_isReset"></span>
+    <span id="round_isP1Winners"></span>
+
+    <span id="p1_name"></span>
+    <span id="p1_tag"></span>
+    <span id="p1_nation"></span>
+
+    <span id="p2_name"></span>
+    <span id="p2_tag"></span>
+    <span id="p2_nation"></span>
+
+
+    <span id="comms_host"></span>
+    <span id="comms_commentator_1"></span>
+    <span id="comms_commentator_2"></span>
+
+    <script>
+    let updateMetadataInterval = window.setInterval(async() => await updateMetadata(), 1000);
+
+    </script>
+
+</body>
+
+
+</html>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,12 @@
             <version>5.7.1</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20230227</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/fetchControllerData.js
+++ b/src/fetchControllerData.js
@@ -1,0 +1,19 @@
+async function updateMetadata() {
+    let metadata;
+
+    try {
+        metadata = await (await fetch("http://127.0.0.1:2086/metadata", {"Content-Type": "application/json"})).json()
+    } catch(e) {console.log(`Failed to connect to server. \n${e}`)}
+    
+    //Loop over each section
+    for (let [section, sectiondata] of Object.entries(metadata)) {
+
+        // Then the data within each section
+        for (let [key, value] of Object.entries(sectiondata)) {
+            try {
+                document.getElementById(`${section}_${key}`).textContent = value;
+            } catch(e) {};
+        }
+    }
+
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -3,6 +3,8 @@ module com.example.filegen {
     requires javafx.fxml;
     requires ini4j;
     requires com.opencsv;
+    requires jdk.httpserver;
+    requires org.json;
 
 
     opens pl.cheily.filegen to javafx.fxml;

--- a/src/main/java/pl/cheily/filegen/LocalData/DataHttpServer.java
+++ b/src/main/java/pl/cheily/filegen/LocalData/DataHttpServer.java
@@ -1,0 +1,100 @@
+package pl.cheily.filegen.LocalData;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.json.*;
+
+import static pl.cheily.filegen.ScoreboardApplication.dataManager;
+import static pl.cheily.filegen.LocalData.MetaKey.*;
+
+/**
+ * Basic HTTP server from which JSON data about the current status of the controller can be fetched.
+ * Use {@link DataHttpServer#start()} to start a new server.
+ * Endpoints implemented:
+ * <ul>
+ * <li>/metadata: Returns the current metadata stored in the DataManager.</li>
+ * </ul>
+ * 
+ */
+public class DataHttpServer {
+
+    private static HttpServer serverInstance;
+
+    /**
+     * Starts the HTTP Server within a DataHttpServer instance.
+     * 
+     * @param address {@link InetSocketAddress} for the server to listen on.
+     */
+    public static void start(InetSocketAddress address) throws IOException {
+        serverInstance = HttpServer.create(address, 0);
+        serverInstance.createContext("/metadata", new MetadataHandler());
+        serverInstance.setExecutor(null);
+        serverInstance.start();
+    }
+
+    static class MetadataHandler implements HttpHandler {
+        public void handle(HttpExchange t) throws IOException {
+            // Create JSON object
+            JSONObject jsonObject = new JSONObject();
+
+            // And add all the data needed from the DataManager.
+
+            //Round data
+            JSONObject roundObject = new JSONObject();
+
+            roundObject.put("label", dataManager.getMeta(SEC_ROUND, KEY_ROUND_LABEL));
+            roundObject.put("score_p1", dataManager.getMeta(SEC_ROUND, KEY_SCORE_1));
+            roundObject.put("score_p2", dataManager.getMeta(SEC_ROUND, KEY_SCORE_2));
+            roundObject.put("isGF", dataManager.getMeta(SEC_ROUND, KEY_GF));
+            roundObject.put("isReset", dataManager.getMeta(SEC_ROUND, KEY_GF_RESET));
+            roundObject.put("isP1Winners", dataManager.getMeta(SEC_ROUND, KEY_GF_W1));
+
+            jsonObject.put("round", roundObject);
+
+
+            // P1 Data
+            JSONObject p1Object = new JSONObject();
+
+            p1Object.put("name", dataManager.getMeta(SEC_P1, KEY_NAME));
+            p1Object.put("tag", dataManager.getMeta(SEC_P1, KEY_TAG));
+            p1Object.put("nation", dataManager.getMeta(SEC_P1, KEY_NATION));
+
+            jsonObject.put("p1", p1Object);
+
+
+            // P2 Data
+            JSONObject p2Object = new JSONObject();
+
+            p2Object.put("name", dataManager.getMeta(SEC_P2, KEY_NAME));
+            p2Object.put("tag", dataManager.getMeta(SEC_P2, KEY_TAG));
+            p2Object.put("nation", dataManager.getMeta(SEC_P2, KEY_NATION));
+
+            jsonObject.put("p2", p2Object);
+
+            
+            // Commentator Data
+            JSONObject commsObject = new JSONObject();
+
+            commsObject.put("host", dataManager.getMeta(SEC_COMMS, KEY_HOST));
+            commsObject.put("commentator_1", dataManager.getMeta(SEC_COMMS, KEY_COMM_1));
+            commsObject.put("commentator_2", dataManager.getMeta(SEC_COMMS, KEY_COMM_2));
+
+            jsonObject.put("comms", commsObject);
+            
+
+            // Set headers
+            t.getResponseHeaders().set("content-type", "application/json");
+            t.getResponseHeaders().set("access-control-allow-origin", "*");
+            t.sendResponseHeaders(200, jsonObject.toString().getBytes().length);
+
+            // Write JSON object to response body
+            OutputStream os = t.getResponseBody();
+            os.write(jsonObject.toString().getBytes());
+            os.close();
+        }
+    }
+}

--- a/src/main/java/pl/cheily/filegen/ScoreboardApplication.java
+++ b/src/main/java/pl/cheily/filegen/ScoreboardApplication.java
@@ -4,11 +4,13 @@ import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
+import pl.cheily.filegen.LocalData.DataHttpServer;
 import pl.cheily.filegen.LocalData.DataManager;
 import pl.cheily.filegen.LocalData.DefaultOutputFormatter;
 import pl.cheily.filegen.LocalData.RawOutputWriter;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 
 public class ScoreboardApplication extends Application {
     public static Scene controllerScene,
@@ -23,6 +25,14 @@ public class ScoreboardApplication extends Application {
     public static DataManager dataManager;
     private static Stage mainStage;
 
+    /**
+     * An HTTP server initialised at runtime, can be connected to within OBS to dynamically update a browser source on metadata save.
+     * Will be listening on 127.0.0.1:2086 by default. <br/>
+     * 
+     * TODO: Avoid using final in order to add config to change address to listen to.
+     */
+    public static final DataHttpServer dataHttpServer = new DataHttpServer();
+
     @Override
     public void start(Stage stage) throws IOException {
         mainStage = stage;
@@ -34,6 +44,8 @@ public class ScoreboardApplication extends Application {
         mainStage.setResizable(false);
         mainStage.setScene(controllerScene);
         mainStage.show();
+
+        dataHttpServer.start(new InetSocketAddress("127.0.0.1", 2086));
     }
 
     public static void setControllerScene() {


### PR DESCRIPTION
This is just a basic framework for using a HTTP server to dynamically fetch the current metadata of the controller.

This allows a JS script, running within OBS, to request the data of the controller via HTTP, avoiding slow and awkward file handling or disabling CORS. 
This also allows for loading a singular constant index.html file, without having to re-write HTML files and refresh browser sources.

This fork also has a sample index.html file and JS script (src/fetchControllerData.js) to demonstrate the functionality of the server.

Again, this is very barebones, and leaves much to be desired (my Java skills are... interesting) but I thought I'd just make a pull request before I find myself sitting here for ages messing around.